### PR TITLE
chore: Refactor Oneshot channel to Request Response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(clippy::print_stderr)]
 
 pub mod batch_coordinator;
+mod utils;
 mod broker;
 pub mod messages;
 mod segment;

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -7,7 +7,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::{DashMap, Entry, iter::IterMut};
 
-use crate::{batch_coordinator::TopicIdPartition, error::RisklessResult};
+use crate::{
+    batch_coordinator::TopicIdPartition, error::RisklessResult, utils::request_response::Request,
+};
 
 use super::produce_response::ProduceResponse;
 
@@ -22,7 +24,7 @@ pub struct ProduceRequest {
 #[derive(Debug)]
 pub struct ProduceRequestCollection {
     inner: DashMap<TopicIdPartition, Vec<ProduceRequest>>,
-    response_senders: DashMap<u32, tokio::sync::oneshot::Sender<ProduceResponse>>,
+    response_senders: DashMap<u32, Request<ProduceRequest, ProduceResponse>>,
     size: AtomicU64,
 }
 
@@ -46,7 +48,7 @@ impl ProduceRequestCollection {
     /// to allocate a new HashMap unnecessarily.
     pub fn extract_response_senders(
         &mut self,
-    ) -> DashMap<u32, tokio::sync::oneshot::Sender<ProduceResponse>> {
+    ) -> DashMap<u32, Request<ProduceRequest, ProduceResponse>> {
         let mut hmap = DashMap::new();
 
         std::mem::swap(&mut hmap, &mut self.response_senders);
@@ -59,16 +61,11 @@ impl ProduceRequestCollection {
         self.size = AtomicU64::new(0);
     }
 
-    pub fn collect(
-        &self,
-        (req, sender): (
-            ProduceRequest,
-            tokio::sync::oneshot::Sender<ProduceResponse>,
-        ),
-    ) -> RisklessResult<()> {
-        tracing::info!("Collecting: {} {:#?}", req.request_id, sender);
+    pub fn collect(&self, req: Request<ProduceRequest, ProduceResponse>) -> RisklessResult<()> {
+        tracing::info!("Collecting: {:#?}", req);
 
-        self.response_senders.insert(req.request_id, sender);
+        let wrapped_request = req;
+        let req = wrapped_request.inner();
 
         let topic_id_partition = TopicIdPartition(req.topic.clone(), req.partition);
 
@@ -78,14 +75,17 @@ impl ProduceRequestCollection {
             Entry::Occupied(mut occupied_entry) => {
                 self.size
                     .fetch_add(TryInto::<u64>::try_into(req.data.len())?, Ordering::Relaxed);
-                occupied_entry.get_mut().push(req);
+                occupied_entry.get_mut().push(req.clone());
             }
             Entry::Vacant(vacant_entry) => {
                 self.size
                     .fetch_add(TryInto::<u64>::try_into(req.data.len())?, Ordering::Relaxed);
-                vacant_entry.insert(vec![req]);
+                vacant_entry.insert(vec![req.clone()]);
             }
         }
+
+        self.response_senders
+            .insert(req.request_id, wrapped_request);
 
         Ok(())
     }

--- a/src/utils/request_response.rs
+++ b/src/utils/request_response.rs
@@ -1,2 +1,45 @@
+//! Request/Response - ideally just to make code more readable.
+//! This is pretty much just a thin wrapper around tokio's oneshot channel
+//! with some added coupling for the data that is part of the 'request'.
+use crate::error::RisklessResult;
+use std::fmt::Debug;
 
+/// Request wraps a generic type as well as a sender for the type.
+#[derive(Debug)]
+pub struct Request<REQ: Sync + Send + Debug, RES: Sync + Send + Debug>(
+    REQ,
+    tokio::sync::oneshot::Sender<RES>,
+);
 
+impl<REQ: Sync + Send + Debug, RES: Sync + Send + Debug> Request<REQ, RES> {
+    /// Creates a new Request from the given generic data type.
+    pub fn new(req: REQ) -> (Self, Response<RES>) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        (Self(req, tx), Response::new(rx))
+    }
+
+    pub fn inner(&self) -> &REQ {
+        &self.0
+    }
+
+    /// Respond with the response value.
+    pub fn respond(self, val: RES) -> Result<(), RES> {
+        self.1.send(val)
+    }
+}
+
+/// Response wraps the receiver for this value.
+pub struct Response<RES>(tokio::sync::oneshot::Receiver<RES>);
+
+impl<RES> Response<RES> {
+    /// Creates a new Response given the receiver for this value.
+    pub fn new(rx: tokio::sync::oneshot::Receiver<RES>) -> Self {
+        Self(rx)
+    }
+
+    /// Await this response value.
+    pub async fn recv(self) -> RisklessResult<RES> {
+        Ok(self.0.await?)
+    }
+}


### PR DESCRIPTION
# Description

Refactored usage of one shot to request/response structs. This (hopefully) makes it slightly more readable and gives codehints as to what the program is trying to use the construct for.