### PR TITLE
feat: Adjust Consume API to parallelize work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riskless"
-version = "0.1.5"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riskless"
-version = "0.1.5"
+version = "0.2.1"
 edition = "2024"
 description = "A pure Rust implementation of Diskless Topics"
 license = "MIT / Apache-2.0"

--- a/src/messages/consume_response.rs
+++ b/src/messages/consume_response.rs
@@ -1,5 +1,10 @@
 use bytes::Bytes;
 
+use crate::{
+    batch_coordinator::{BatchInfo, FindBatchResponse},
+    error::RisklessError,
+};
+
 #[derive(Debug, Clone)]
 pub struct ConsumeBatch {
     pub topic: String,
@@ -12,4 +17,35 @@ pub struct ConsumeBatch {
 #[derive(Debug, Clone)]
 pub struct ConsumeResponse {
     pub batches: Vec<ConsumeBatch>,
+}
+
+/// Very specific implementation for converting these data values.
+impl TryFrom<(FindBatchResponse, &BatchInfo, &Bytes)> for ConsumeBatch {
+    type Error = RisklessError;
+
+    fn try_from(
+        (find_batch_response, batch_info, bytes): (FindBatchResponse, &BatchInfo, &bytes::Bytes),
+    ) -> Result<Self, Self::Error> {
+        // index into the bytes.
+        let start: usize =
+            (batch_info.metadata.base_offset + batch_info.metadata.byte_offset).try_into()?;
+        let end: usize = (batch_info.metadata.base_offset
+            + batch_info.metadata.byte_offset
+            + Into::<u64>::into(batch_info.metadata.byte_size))
+        .try_into()?;
+
+        tracing::info!("START: {} END: {} ", start, end);
+
+        let data = bytes.slice(start..end);
+
+        let batch = ConsumeBatch {
+            topic: batch_info.metadata.topic_id_partition.0.clone(),
+            partition: batch_info.metadata.topic_id_partition.1,
+            offset: find_batch_response.log_start_offset,
+            max_partition_fetch_bytes: 0,
+            data,
+        };
+
+        Ok(batch)
+    }
 }


### PR DESCRIPTION
# Description

As opposed to running all get requests in parallel and awaiting all of them for cosume requests, it was preferred to potentially return a stream of responses that could be buffered. This would effectively allow a consumer to timeout the function and avoid awaiting the longest get request. 