### PR TITLE
feat: Heartbeat File Deletion

### DIFF
--- a/src/simple_batch_coordinator/simple.rs
+++ b/src/simple_batch_coordinator/simple.rs
@@ -264,6 +264,7 @@ impl BatchCoordinator for SimpleBatchCoordinator {
 
     /// No-op as this operation is not supported in the SimpleBatchCoordinator.
     async fn delete_files(&self, _request: DeleteFilesRequest) {}
+    
     /// Always returns false.
     async fn is_safe_to_delete_file(&self, _object_key: String) -> bool {
         false

--- a/tests/broker.rs
+++ b/tests/broker.rs
@@ -648,7 +648,7 @@ mod tests {
 
         let mut broker = Broker::new(config);
 
-        let _result = broker.heartbeat_permanent_delete().await.unwrap();
+        broker.heartbeat_permanent_delete().await.unwrap();
 
         tear_down_dirs(batch_coord_path, object_store_path);
     }


### PR DESCRIPTION
# Description 

In order for the Broker to handle File deletions, it should be able to query the files ready to delete from the underlying BatchCoordinator and then delete those files. The BatchCoordinator then gets notified of the deletion. 

This is primarily done within the broker <> BatchCoordinator interaction and the implementor simply heartbeats this action periodically. Deletion of Records is done by the implementor and the BatchCoordinator handles when a file's references have been deleted. 