### PR TITLE
chore: Add Unwrap Clippy Lint

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Clippy
-        run: cargo clippy --all-features --all-targets
+        run: cargo clippy --all-features 
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riskless"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riskless"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "A pure Rust implementation of Diskless Topics"
 license = "MIT / Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // #![deny(missing_docs)]
 #![deny(clippy::print_stdout)]
 #![deny(clippy::print_stderr)]
+#![deny(clippy::unwrap_used)]
+
 
 pub mod batch_coordinator;
 mod utils;


### PR DESCRIPTION
# Description

We ideally don't want the behaviour of this library panic'ing at runtime. This PR works to remove all unwrap's as well as implementing  a clippy lint for it. 