### PR TITLE
feat: Decompose BatchCoordinator Trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riskless"
-version = "0.5.2"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riskless"
-version = "0.5.2"
+version = "0.6.1"
 edition = "2024"
 description = "A pure Rust implementation of Diskless Topics"
 license = "MIT / Apache-2.0"

--- a/src/batch_coordinator/simple/mod.rs
+++ b/src/batch_coordinator/simple/mod.rs
@@ -15,10 +15,11 @@ use uuid::Uuid;
 use crate::{batch_coordinator::BatchInfo, error::RisklessResult, messages::CommitBatchRequest};
 
 use crate::batch_coordinator::{
-    BatchCoordinator, BatchMetadata, CommitBatchResponse, CreateTopicAndPartitionsRequest,
-    DeleteFilesRequest, DeleteRecordsRequest, DeleteRecordsResponse, FileToDelete,
-    FindBatchRequest, FindBatchResponse, ListOffsetsRequest, ListOffsetsResponse,
+    BatchMetadata, CommitBatchResponse, DeleteFilesRequest, DeleteRecordsRequest,
+    DeleteRecordsResponse, FileToDelete, FindBatchRequest, FindBatchResponse,
 };
+
+use super::{CommitFile, DeleteFiles, FindBatches};
 
 /// The SimpleBatchCoordinator is a default implementation that is
 ///
@@ -95,15 +96,7 @@ impl SimpleBatchCoordinator {
 }
 
 #[async_trait::async_trait]
-impl BatchCoordinator for SimpleBatchCoordinator {
-    async fn create_topic_and_partitions(
-        &self,
-        _requests: HashSet<CreateTopicAndPartitionsRequest>,
-    ) {
-        // This is not implemented for SimpleBatchCoordinator as the topics + partitions get
-        // created as they have data produced to them.
-    }
-
+impl CommitFile for SimpleBatchCoordinator {
     async fn commit_file(
         &self,
         object_key: [u8; 16],
@@ -163,7 +156,10 @@ impl BatchCoordinator for SimpleBatchCoordinator {
 
         commit_batch_responses
     }
+}
 
+#[async_trait::async_trait]
+impl FindBatches for SimpleBatchCoordinator {
     async fn find_batches(
         &self,
         find_batch_requests: Vec<FindBatchRequest>,
@@ -295,11 +291,10 @@ impl BatchCoordinator for SimpleBatchCoordinator {
 
         results
     }
+}
 
-    async fn list_offsets(&self, _requests: Vec<ListOffsetsRequest>) -> Vec<ListOffsetsResponse> {
-        todo!()
-    }
-
+#[async_trait::async_trait]
+impl DeleteFiles for SimpleBatchCoordinator {
     /// Simply returns errors as this implementation does not support this operation.
     async fn delete_records(
         &self,


### PR DESCRIPTION
# Description

The BatchCoordinator trait is quite verbose and is generally not needed in each method that is within Riskless. For implementation, it could be better developer experience to just implement one subset of traits that require a specific set of methods as oppose to implementing the entirety of the BatchCoordinator trait. 