### PR TITLE
fix: Error Logging for Consume.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riskless"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riskless"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "A pure Rust implementation of Diskless Topics"
 license = "MIT / Apache-2.0"


### PR DESCRIPTION
# Description

Consumption query is not super informative when it comes to errors or the lack of data being consumed. Therefore it was seen as necessary to add logging. 